### PR TITLE
Fix for limited amount of syscalls (Issue #97). Max amount of syscall…

### DIFF
--- a/library/src/micros/micros_console.c
+++ b/library/src/micros/micros_console.c
@@ -5,17 +5,17 @@ micros_console_color background_color = micros_console_color_black;
 
 void micros_console_print_char(char c)
 {
-    micros_interrupt_3a(0x10, (uint32_t)c, (uint32_t)foreground_color, (uint32_t)background_color);
+    micros_interrupt_3a(0x0100, (uint32_t)c, (uint32_t)foreground_color, (uint32_t)background_color);
 }
 
 void micros_console_print_string(const char *str)
 {
-    micros_interrupt_3a(0x11, (uint32_t)str, (uint32_t)foreground_color, (uint32_t)background_color);
+    micros_interrupt_3a(0x0101, (uint32_t)str, (uint32_t)foreground_color, (uint32_t)background_color);
 }
 
 char micros_console_get_char_at_position(micros_console_position *position)
 {
-    return (char)micros_interrupt_2a(0x12, position->x, position->y);
+    return (char)micros_interrupt_2a(0x0102, position->x, position->y);
 }
 
 void micros_console_set_foreground_color(micros_console_color color)
@@ -30,30 +30,30 @@ void micros_console_set_background_color(micros_console_color color)
 
 void micros_console_set_cursor_position(micros_console_position *position)
 {
-    micros_interrupt_2a(0x13, position->x, position->y);
+    micros_interrupt_2a(0x0103, position->x, position->y);
 }
 
 void micros_console_get_cursor_position(micros_console_position *position)
 {
-    micros_interrupt_1a(0x14, (uint32_t)position);
+    micros_interrupt_1a(0x0104, (uint32_t)position);
 }
 
 void micros_console_clear()
 {
-    micros_interrupt_0a(0x15);
+    micros_interrupt_0a(0x0105);
 }
 
 void micros_console_set_cursor_visibility(bool visibility)
 {
-    micros_interrupt_1a(0x16, (uint32_t)visibility);
+    micros_interrupt_1a(0x0106, (uint32_t)visibility);
 }
 
 void micros_console_set_video_mode(uint8_t mode)
 {
-    micros_interrupt_1a(0xE0, mode);
+    micros_interrupt_1a(0x010B, mode);
 }
 
 void micros_console_copy_from_buffer(uint8_t* buffer, uint32_t how_many)
 {
-    micros_interrupt_2a(0xE1, (uint32_t)buffer, how_many);
+    micros_interrupt_2a(0x010C, (uint32_t)buffer, how_many);
 }

--- a/library/src/micros/micros_filesystem.c
+++ b/library/src/micros/micros_filesystem.c
@@ -2,77 +2,77 @@
 
 bool micros_filesystem_get_file_info(const char *path, micros_filesystem_file_info *file_info)
 {
-    return micros_interrupt_2a(0x50, (uint32_t)path, (uint32_t)file_info);
+    return micros_interrupt_2a(0x0500, (uint32_t)path, (uint32_t)file_info);
 }
 
 bool micros_filesystem_get_directory_info( const char *path, micros_filesystem_directory_info *directory_info)
 {
-    return micros_interrupt_2a(0x51, (uint32_t)path, (uint32_t)directory_info);
+    return micros_interrupt_2a(0x0501, (uint32_t)path, (uint32_t)directory_info);
 }
 
 bool micros_filesystem_read_file( const char *path, uint8_t *buffer,  const uint32_t start_index,  const uint32_t length)
 {
-    return micros_interrupt_4a(0x52, (uint32_t)path, (uint32_t)buffer, start_index, length);
+    return micros_interrupt_4a(0x0502, (uint32_t)path, (uint32_t)buffer, start_index, length);
 }
 
 uint32_t micros_filesystem_get_entries_count_in_directory(const char *path)
 {
-    return micros_interrupt_1a(0x53, (uint32_t)path);
+    return micros_interrupt_1a(0x0503, (uint32_t)path);
 }
 
 bool micros_filesystem_get_entries_in_directory(const char *path, char **entries)
 {
-    return micros_interrupt_2a(0x54, (uint32_t)path, (uint32_t)entries);
+    return micros_interrupt_2a(0x0504, (uint32_t)path, (uint32_t)entries);
 }
 
 bool micros_filesystem_is_file(const char *path)
 {
-    return micros_interrupt_1a(0x55, (uint32_t)path);
+    return micros_interrupt_1a(0x0505, (uint32_t)path);
 }
 
 bool micros_filesystem_is_directory(const char *path)
 {
-    return micros_interrupt_1a(0x56, (uint32_t)path);
+    return micros_interrupt_1a(0x0506, (uint32_t)path);
 }
 
 bool micros_filesystem_create_file(const char *path)
 {
-    return micros_interrupt_1a(0x57, (uint32_t)path);
+    return micros_interrupt_1a(0x0507, (uint32_t)path);
 }
 
 bool micros_filesystem_create_directory(const char *path)
 {
-    return micros_interrupt_1a(0x58, (uint32_t)path);
+    return micros_interrupt_1a(0x0508, (uint32_t)path);
 }
 
 bool micros_filesystem_delete_file(const char *path)
 {
-    return micros_interrupt_1a(0x59, (uint32_t)path);
+    return micros_interrupt_1a(0x0509, (uint32_t)path);
 }
 
 bool micros_filesystem_delete_directory(const char *path)
 {
-    return micros_interrupt_1a(0x5A, (uint32_t)path);
+    return micros_interrupt_1a(0x050A, (uint32_t)path);
 }
 
 bool micros_filesystem_rename_file(const char *path, const char *new_name)
 {
-    return micros_interrupt_2a(0x5B, (uint32_t)path, (uint32_t)new_name);
+    return micros_interrupt_2a(0x050B, (uint32_t)path, (uint32_t)new_name);
 }
 
 bool micros_filesystem_rename_directory(const char *path, const char *new_name)
 {
-    return micros_interrupt_2a(0x5C, (uint32_t)path, (uint32_t)new_name);
+    return micros_interrupt_2a(0x050C, (uint32_t)path, (uint32_t)new_name);
 }
 
 bool micros_filesystem_save_to_file(const char *path, const char *buffer, const int size)
 {
-    return micros_interrupt_3a(0x5D, (uint32_t)path, (uint32_t)buffer, size);
+    return micros_interrupt_3a(0x050D, (uint32_t)path, (uint32_t)buffer, size);
 }
 
 bool micros_filesystem_append_to_file(const char *path, const char *buffer, const int size)
 {
-    return micros_interrupt_3a(0x5E, (uint32_t)path, (uint32_t)buffer, size);
+    return micros_interrupt_3a(0x050E, (uint32_t)path, (uint32_t)buffer, size);
 }
 
 bool micros_filesystem_file_exists(const char *path)
@@ -89,10 +89,10 @@ bool micros_filesystem_directory_exists(const char *path)
 
 int micros_filesystem_get_free_space(const char partition_symbol)
 {
-    return micros_interrupt_1a(0x70, (uint32_t)partition_symbol);
+    return micros_interrupt_1a(0x050F, (uint32_t)partition_symbol);
 }
 
 int micros_filesystem_get_total_space(const char partition_symbol)
 {
-    return micros_interrupt_1a(0x71, (uint32_t)partition_symbol);
+    return micros_interrupt_1a(0x0510, (uint32_t)partition_symbol);
 }

--- a/library/src/micros/micros_generic_vga.c
+++ b/library/src/micros/micros_generic_vga.c
@@ -2,20 +2,20 @@
 
 void micros_generic_vga_set_video_mode(uint16_t mode)
 {
-    micros_interrupt_1a(0x17, (uint32_t)mode);
+    micros_interrupt_1a(0x0107, (uint32_t)mode);
 }
 
 bool micros_generic_vga_is_text_mode()
 {
-    return micros_interrupt_0a(0x18);
+    return micros_interrupt_0a(0x0108);
 }
 
 uint16_t micros_generic_vga_get_current_video_mode()
 {
-    return micros_interrupt_0a(0x19);
+    return micros_interrupt_0a(0x0109);
 }
 
 uint8_t micros_generic_vga_is_vretrace()
 {
-    return micros_interrupt_0a(0x1A);
+    return micros_interrupt_0a(0x010A);
 }

--- a/library/src/micros/micros_heap.c
+++ b/library/src/micros/micros_heap.c
@@ -2,30 +2,30 @@
 
 void *micros_heap_alloc(uint32_t size, uint32_t align)
 {
-    return (void *)micros_interrupt_2a(0x00, size, align);
+    return (void *)micros_interrupt_2a(0x0000, size, align);
 }
 
 void *micros_heap_realloc(void *ptr, uint32_t size)
 {
-    return (void *)micros_interrupt_3a(0x01, (uint32_t)ptr, size, 0);
+    return (void *)micros_interrupt_3a(0x0001, (uint32_t)ptr, size, 0);
 }
 
 void micros_heap_dealloc(void *ptr)
 {
-    micros_interrupt_1a(0x02, (uint32_t)ptr);
+    micros_interrupt_1a(0x0002, (uint32_t)ptr);
 }
 
 uint32_t micros_heap_get_object_size(void *ptr)
 {
-    return micros_interrupt_1a(0x03, (uint32_t)ptr);
+    return micros_interrupt_1a(0x0003, (uint32_t)ptr);
 }
 
 bool micros_heap_verify_integrity()
 {
-    return micros_interrupt_0a(0x04);
+    return micros_interrupt_0a(0x0004);
 }
 
 micros_heap_entry *micros_heap_get_process_heap()
 {
-    return (micros_heap_entry *)micros_interrupt_0a(0x05);
+    return (micros_heap_entry *)micros_interrupt_0a(0x0005);
 }

--- a/library/src/micros/micros_keyboard.c
+++ b/library/src/micros/micros_keyboard.c
@@ -2,12 +2,12 @@
 
 bool micros_keyboard_is_key_pressed()
 {
-    return micros_interrupt_0a(0x20);
+    return micros_interrupt_0a(0x0200);
 }
 
 bool micros_keyboard_get_pressed_key(micros_keyboard_scan_ascii_pair *scan_ascii_pair)
 {
-    return micros_interrupt_1a(0x21, (uint32_t)scan_ascii_pair);
+    return micros_interrupt_1a(0x0201, (uint32_t)scan_ascii_pair);
 }
 
 void micros_keyboard_wait_for_key_press(micros_keyboard_scan_ascii_pair *scan_ascii_pair)
@@ -16,14 +16,14 @@ void micros_keyboard_wait_for_key_press(micros_keyboard_scan_ascii_pair *scan_as
     // and releasing keys. That's why we need to do a little hack and skip releasing keys
     // by waiting for an empty buffer.
     
-    micros_interrupt_0a(0x22);
+    micros_interrupt_0a(0x0202);
     while (!micros_keyboard_get_pressed_key(scan_ascii_pair))
     {
-        micros_interrupt_0a(0x22);
+        micros_interrupt_0a(0x0202);
     }
 }
 
 bool micros_keyboard_get_key_state(micros_keyboard_keys scancode)
 {
-    return micros_interrupt_1a(0x23, scancode);
+    return micros_interrupt_1a(0x0203, scancode);
 }

--- a/library/src/micros/micros_memory.c
+++ b/library/src/micros/micros_memory.c
@@ -2,5 +2,5 @@
 
 void micros_memory_get_physical_memory_stats(micros_physical_memory_stats *stats)
 {
-    micros_interrupt_1a(0xA0, (uint32_t)stats);
+    micros_interrupt_1a(0x0A00, (uint32_t)stats);
 }

--- a/library/src/micros/micros_partitions.c
+++ b/library/src/micros/micros_partitions.c
@@ -2,15 +2,15 @@
 
 int micros_partitions_get_count()
 {
-    return micros_interrupt_0a(0xB0);
+    return micros_interrupt_0a(0x0B00);
 }
 
 void micros_partitions_get_symbols(char *symbols_array)
 {
-    micros_interrupt_1a(0xB1, (uint32_t)symbols_array);
+    micros_interrupt_1a(0x0B01, (uint32_t)symbols_array);
 }
 
 void micros_partitions_get_info(char symbol, micros_partition_info *partition_info)
 {
-    micros_interrupt_2a(0xB2, (uint32_t)symbol, (uint32_t)partition_info);
+    micros_interrupt_2a(0x0B02, (uint32_t)symbol, (uint32_t)partition_info);
 }

--- a/library/src/micros/micros_pc_speaker.c
+++ b/library/src/micros/micros_pc_speaker.c
@@ -2,10 +2,10 @@
 
 void micros_pc_speaker_enable_sound(uint32_t frequency)
 {
-    micros_interrupt_1a(0x80, frequency);
+    micros_interrupt_1a(0x0800, frequency);
 }
 
 void micros_pc_speaker_disable_sound()
 {
-    micros_interrupt_0a(0x81);
+    micros_interrupt_0a(0x0801);
 }

--- a/library/src/micros/micros_power.c
+++ b/library/src/micros/micros_power.c
@@ -2,10 +2,10 @@
 
 void micros_power_reboot()
 {
-    micros_interrupt_0a(0xC0);
+    micros_interrupt_0a(0x0C00);
 }
 
 void micros_power_shutdown()
 {
-    micros_interrupt_0a(0xC1);
+    micros_interrupt_0a(0x0C01);
 }

--- a/library/src/micros/micros_process.c
+++ b/library/src/micros/micros_process.c
@@ -12,7 +12,7 @@ uint32_t micros_process_get_processes_count()
 
 void micros_process_get_current_process_info(micros_process_user_info *user_info)
 {
-    micros_interrupt_1a(0x7020, (uint32_t)user_info);
+    micros_interrupt_1a(0x0702, (uint32_t)user_info);
 }
 
 bool micros_process_get_process_info(uint32_t id, micros_process_user_info *user_info)

--- a/library/src/micros/micros_process.c
+++ b/library/src/micros/micros_process.c
@@ -2,57 +2,57 @@
 
 void micros_process_exit_process(int status)
 {
-    micros_interrupt_2a(0x90, status, false);
+    micros_interrupt_2a(0x0700, status, false);
 }
 
 uint32_t micros_process_get_processes_count()
 {
-    return micros_interrupt_0a(0x91);
+    return micros_interrupt_0a(0x0701);
 }
 
 void micros_process_get_current_process_info(micros_process_user_info *user_info)
 {
-    micros_interrupt_1a(0x92, (uint32_t)user_info);
+    micros_interrupt_1a(0x7020, (uint32_t)user_info);
 }
 
 bool micros_process_get_process_info(uint32_t id, micros_process_user_info *user_info)
 {
-    return micros_interrupt_2a(0x93, id, (uint32_t)user_info);
+    return micros_interrupt_2a(0x0703, id, (uint32_t)user_info);
 }
 
 void micros_process_get_all_processes_info(micros_process_user_info *user_info)
 {
-    micros_interrupt_1a(0x94, (uint32_t)user_info);
+    micros_interrupt_1a(0x0704, (uint32_t)user_info);
 }
 
 void micros_process_set_current_process_name(char *name)
 {
-    micros_interrupt_1a(0x95, (uint32_t)name);
+    micros_interrupt_1a(0x0705, (uint32_t)name);
 }
 
 void micros_process_current_process_sleep(uint32_t milliseconds)
 {
-    micros_interrupt_1a(0x96, milliseconds);
+    micros_interrupt_1a(0x0706, milliseconds);
 }
 
 uint32_t micros_process_start_process(char *path, char *arguments, bool child, bool active)
 {
-    return micros_interrupt_4a(0x97, (uint32_t)path, (uint32_t)arguments, (uint32_t)child, (uint32_t)active);
+    return micros_interrupt_4a(0x0707, (uint32_t)path, (uint32_t)arguments, (uint32_t)child, (uint32_t)active);
 }
 
 void micros_process_set_current_process_signal_handler(void (*signal_handler)(micros_signal_params*))
 {
-    micros_interrupt_1a(0x98, (uint32_t)signal_handler);
+    micros_interrupt_1a(0x0708, (uint32_t)signal_handler);
 }
 
 void micros_process_finish_signal_handler(micros_signal_params *old_state)
 {
-    micros_interrupt_1a(0x99, (uint32_t)old_state);
+    micros_interrupt_1a(0x0709, (uint32_t)old_state);
 }
 
 void micros_process_wait_for_process(uint32_t process_id_to_wait)
 {
-    micros_interrupt_1a(0x9A, process_id_to_wait);
+    micros_interrupt_1a(0x070A, process_id_to_wait);
 }
 
 uint32_t micros_process_start_thread(void *entry_point, void *param)
@@ -65,10 +65,10 @@ uint32_t micros_process_start_thread(void *entry_point, void *param)
     *(stack - 1) = (uint32_t)param;
     *(stack - 2) = (uint32_t)micros_process_abort_thread;
     
-    return micros_interrupt_2a(0x9B, (uint32_t)entry_point, (uint32_t)stack);
+    return micros_interrupt_2a(0x070B, (uint32_t)entry_point, (uint32_t)stack);
 }
 
 void micros_process_abort_thread()
 {
-    micros_interrupt_2a(0x90, 0, true);
+    micros_interrupt_2a(0x0700, 0, true);
 }

--- a/library/src/micros/micros_rtc.c
+++ b/library/src/micros/micros_rtc.c
@@ -2,10 +2,10 @@
 
 void micros_rtc_read_time(micros_rtc_time *time)
 {
-    micros_interrupt_1a(0x40, (uint32_t)time);
+    micros_interrupt_1a(0x0400, (uint32_t)time);
 }
 
 void micros_rtc_set_time(micros_rtc_time *time)
 {
-    micros_interrupt_1a(0x41, (uint32_t)time);
+    micros_interrupt_1a(0x0401, (uint32_t)time);
 }

--- a/library/src/micros/micros_serial.c
+++ b/library/src/micros/micros_serial.c
@@ -2,30 +2,30 @@
 
 void micros_serial_init(unsigned int port, unsigned int baud_rate, unsigned int data_bits, unsigned int stop_bits, unsigned int parity)
 {
-    micros_interrupt_5a(0xD0, (uint32_t)port, (uint32_t)baud_rate, (uint32_t)data_bits, (uint32_t)stop_bits, (uint32_t)parity);
+    micros_interrupt_5a(0x0D00, (uint32_t)port, (uint32_t)baud_rate, (uint32_t)data_bits, (uint32_t)stop_bits, (uint32_t)parity);
 }
 
 bool micros_serial_is_busy(unsigned int port)
 {
-    return micros_interrupt_1a(0xD1, (uint32_t)port);
+    return micros_interrupt_1a(0x0D01, (uint32_t)port);
 }
 
 bool micros_serial_is_queue_empty(unsigned int port)
 {
-    return micros_interrupt_1a(0xD2, (uint32_t)port);
+    return micros_interrupt_1a(0x0D02, (uint32_t)port);
 }
 
 void micros_serial_send(unsigned int port, char c)
 {
-    micros_interrupt_2a(0xD3, (uint32_t)port, (uint32_t)c);
+    micros_interrupt_2a(0x0D03, (uint32_t)port, (uint32_t)c);
 }
 
 void micros_serial_send_string(unsigned int port, char *str)
 {
-    micros_interrupt_2a(0xD4, (uint32_t)port, (uint32_t)str);
+    micros_interrupt_2a(0x0D04, (uint32_t)port, (uint32_t)str);
 }
 
 char micros_serial_receive(unsigned int port)
 {
-    return micros_interrupt_1a(0xD5, (uint32_t)port);
+    return micros_interrupt_1a(0x0D05, (uint32_t)port);
 }

--- a/library/src/micros/micros_timer.c
+++ b/library/src/micros/micros_timer.c
@@ -2,5 +2,5 @@
 
 uint32_t micros_timer_get_system_clock()
 {
-    return micros_interrupt_0a(0x60);
+    return micros_interrupt_0a(0x0600);
 }

--- a/os/kernel/src/process/syscalls/syscalls_manager.c
+++ b/os/kernel/src/process/syscalls/syscalls_manager.c
@@ -6,113 +6,111 @@ void syscalls_manager_init()
 {
     idt_attach_syscalls_manager(syscalls_manager_call);
 
-    // 0x0X - Heap
-    syscalls_manager_attach_handler(0x00, syscall_heap_alloc_memory);
-    syscalls_manager_attach_handler(0x01, syscall_heap_realloc_memory);
-    syscalls_manager_attach_handler(0x02, syscall_heap_dealloc_memory);
-    syscalls_manager_attach_handler(0x03, syscall_heap_get_object_size);
-    syscalls_manager_attach_handler(0x04, syscall_heap_verify_integrity);
-    syscalls_manager_attach_handler(0x05, syscall_heap_get_process_heap);
+    // 0x00XX - Heap
+    syscalls_manager_attach_handler(0x0000, syscall_heap_alloc_memory);
+    syscalls_manager_attach_handler(0x0001, syscall_heap_realloc_memory);
+    syscalls_manager_attach_handler(0x0002, syscall_heap_dealloc_memory);
+    syscalls_manager_attach_handler(0x0003, syscall_heap_get_object_size);
+    syscalls_manager_attach_handler(0x0004, syscall_heap_verify_integrity);
+    syscalls_manager_attach_handler(0x0005, syscall_heap_get_process_heap);
 
-    // 0x1X - VGA and generic VGA
-    syscalls_manager_attach_handler(0x10, syscall_terminal_print_char);
-    syscalls_manager_attach_handler(0x11, syscall_terminal_print_string);
-    syscalls_manager_attach_handler(0x12, syscall_terminal_get_char_at_position);
-    syscalls_manager_attach_handler(0x13, syscall_terminal_set_cursor_position);
-    syscalls_manager_attach_handler(0x14, syscall_terminal_get_cursor_position);
-    syscalls_manager_attach_handler(0x15, syscall_terminal_clear);
-    syscalls_manager_attach_handler(0x16, syscall_terminal_set_cursor_visibility);
-    
-    syscalls_manager_attach_handler(0x17, syscall_generic_vga_set_video_mode);
-    syscalls_manager_attach_handler(0x18, syscall_generic_vga_is_text_mode);
-    syscalls_manager_attach_handler(0x19, syscall_generic_vga_get_current_video_mode);
-    syscalls_manager_attach_handler(0x1A, syscall_generic_vga_is_vretrace);
+    // 0x01XX - VGA and generic VGA
+    syscalls_manager_attach_handler(0x0100, syscall_terminal_print_char);
+    syscalls_manager_attach_handler(0x0101, syscall_terminal_print_string);
+    syscalls_manager_attach_handler(0x0102, syscall_terminal_get_char_at_position);
+    syscalls_manager_attach_handler(0x0103, syscall_terminal_set_cursor_position);
+    syscalls_manager_attach_handler(0x0104, syscall_terminal_get_cursor_position);
+    syscalls_manager_attach_handler(0x0105, syscall_terminal_clear);
+    syscalls_manager_attach_handler(0x0106, syscall_terminal_set_cursor_visibility);
+    syscalls_manager_attach_handler(0x0107, syscall_generic_vga_set_video_mode);
+    syscalls_manager_attach_handler(0x0108, syscall_generic_vga_is_text_mode);
+    syscalls_manager_attach_handler(0x0109, syscall_generic_vga_get_current_video_mode);
+    syscalls_manager_attach_handler(0x010A, syscall_generic_vga_is_vretrace);
+    syscalls_manager_attach_handler(0x010B, syscall_terminal_set_video_mode);
+    syscalls_manager_attach_handler(0x010C, syscall_terminal_copy_from_buffer);
 
-    // 0x2X - Keyboard
-    syscalls_manager_attach_handler(0x20, syscall_keyboard_is_key_pressed);
-    syscalls_manager_attach_handler(0x21, syscall_keyboard_get_pressed_key);
-    syscalls_manager_attach_handler(0x22, syscall_keyboard_wait_for_key_press);
-    syscalls_manager_attach_handler(0x23, syscall_keyboard_get_key_state);
 
-    // 0x3X - PCI
+    // 0x02XX - Keyboard
+    syscalls_manager_attach_handler(0x0200, syscall_keyboard_is_key_pressed);
+    syscalls_manager_attach_handler(0x0201, syscall_keyboard_get_pressed_key);
+    syscalls_manager_attach_handler(0x0202, syscall_keyboard_wait_for_key_press);
+    syscalls_manager_attach_handler(0x0203, syscall_keyboard_get_key_state);
 
-    // 0x4X - RTC
-    syscalls_manager_attach_handler(0x40, syscall_rtc_get_time);
-    syscalls_manager_attach_handler(0x41, syscall_rtc_set_time);
+    // 0x03XX - PCI
 
-    // 0x5X - File system
-    syscalls_manager_attach_handler(0x50, syscall_filesystem_get_file_info);
-    syscalls_manager_attach_handler(0x51, syscall_filesystem_get_directory_info);
-    syscalls_manager_attach_handler(0x52, syscall_filesystem_read_file);
-    syscalls_manager_attach_handler(0x53, syscall_filesystem_get_entries_count_in_directory);
-    syscalls_manager_attach_handler(0x54, syscall_filesystem_get_entries_in_directory);
-    syscalls_manager_attach_handler(0x55, syscall_filesystem_is_file);
-    syscalls_manager_attach_handler(0x56, syscall_filesystem_is_directory);
-    syscalls_manager_attach_handler(0x57, syscall_filesystem_create_file);
-    syscalls_manager_attach_handler(0x58, syscall_filesystem_create_directory);
-    syscalls_manager_attach_handler(0x59, syscall_filesystem_delete_file);
-    syscalls_manager_attach_handler(0x5A, syscall_filesystem_delete_directory);
-    syscalls_manager_attach_handler(0x5B, syscall_filesystem_rename_file);
-    syscalls_manager_attach_handler(0x5C, syscall_filesystem_rename_directory);
-    syscalls_manager_attach_handler(0x5D, syscall_filesystem_save_to_file);
-    syscalls_manager_attach_handler(0x5E, syscall_filesystem_append_to_file);
+    // 0x04XX - RTC
+    syscalls_manager_attach_handler(0x0400, syscall_rtc_get_time);
+    syscalls_manager_attach_handler(0x0401, syscall_rtc_set_time);
 
-    // 0x6X - Timer
-    syscalls_manager_attach_handler(0x60, syscall_timer_get_system_clock);
+    // 0x05XX - File system
+    syscalls_manager_attach_handler(0x0500, syscall_filesystem_get_file_info);
+    syscalls_manager_attach_handler(0x0501, syscall_filesystem_get_directory_info);
+    syscalls_manager_attach_handler(0x0502, syscall_filesystem_read_file);
+    syscalls_manager_attach_handler(0x0503, syscall_filesystem_get_entries_count_in_directory);
+    syscalls_manager_attach_handler(0x0504, syscall_filesystem_get_entries_in_directory);
+    syscalls_manager_attach_handler(0x0505, syscall_filesystem_is_file);
+    syscalls_manager_attach_handler(0x0506, syscall_filesystem_is_directory);
+    syscalls_manager_attach_handler(0x0507, syscall_filesystem_create_file);
+    syscalls_manager_attach_handler(0x0508, syscall_filesystem_create_directory);
+    syscalls_manager_attach_handler(0x0509, syscall_filesystem_delete_file);
+    syscalls_manager_attach_handler(0x050A, syscall_filesystem_delete_directory);
+    syscalls_manager_attach_handler(0x050B, syscall_filesystem_rename_file);
+    syscalls_manager_attach_handler(0x050C, syscall_filesystem_rename_directory);
+    syscalls_manager_attach_handler(0x050D, syscall_filesystem_save_to_file);
+    syscalls_manager_attach_handler(0x050E, syscall_filesystem_append_to_file);
+    syscalls_manager_attach_handler(0x050F, syscall_filesystem_get_free_space);
+    syscalls_manager_attach_handler(0x0510, syscall_filesystem_get_total_space);
 
-    // 0x7X - File system 2
-    syscalls_manager_attach_handler(0x70, syscall_filesystem_get_free_space);
-    syscalls_manager_attach_handler(0x71, syscall_filesystem_get_total_space);
+    // 0x06XX - Timer
+    syscalls_manager_attach_handler(0x0600, syscall_timer_get_system_clock);
+
+    // 0x07XX (OLD 0x9X) - Processes
+    syscalls_manager_attach_handler(0x0700, syscall_process_exit);
+    syscalls_manager_attach_handler(0x0701, syscall_process_get_processes_count);
+    syscalls_manager_attach_handler(0x0702, syscall_process_get_current_process_info);
+    syscalls_manager_attach_handler(0x0703, syscall_process_get_process_info);
+    syscalls_manager_attach_handler(0x0704, syscall_process_get_all_processes_info);
+    syscalls_manager_attach_handler(0x0705, syscall_process_set_current_process_name);
+    syscalls_manager_attach_handler(0x0706, syscall_process_current_process_sleep);
+    syscalls_manager_attach_handler(0x0707, syscall_process_start_process);
+    syscalls_manager_attach_handler(0x0708, syscall_process_set_current_process_signal_handler);
+    syscalls_manager_attach_handler(0x0709, syscall_process_finish_signal_handler);
+    syscalls_manager_attach_handler(0x070A, syscall_process_wait_for_process);
+    syscalls_manager_attach_handler(0x070B, syscall_process_start_thread);
 
     // 0x8X - PC Speaker
-    syscalls_manager_attach_handler(0x80, syscall_pc_speaker_enable_sound);
-    syscalls_manager_attach_handler(0x81, syscall_pc_speaker_disable_sound);
+    syscalls_manager_attach_handler(0x0800, syscall_pc_speaker_enable_sound);
+    syscalls_manager_attach_handler(0x0801, syscall_pc_speaker_disable_sound);
 
-    // 0x9X - Processes
-    syscalls_manager_attach_handler(0x90, syscall_process_exit);
-    syscalls_manager_attach_handler(0x91, syscall_process_get_processes_count);
-    syscalls_manager_attach_handler(0x92, syscall_process_get_current_process_info);
-    syscalls_manager_attach_handler(0x93, syscall_process_get_process_info);
-    syscalls_manager_attach_handler(0x94, syscall_process_get_all_processes_info);
-    syscalls_manager_attach_handler(0x95, syscall_process_set_current_process_name);
-    syscalls_manager_attach_handler(0x96, syscall_process_current_process_sleep);
-    syscalls_manager_attach_handler(0x97, syscall_process_start_process);
-    syscalls_manager_attach_handler(0x98, syscall_process_set_current_process_signal_handler);
-    syscalls_manager_attach_handler(0x99, syscall_process_finish_signal_handler);
-    syscalls_manager_attach_handler(0x9A, syscall_process_wait_for_process);
-    syscalls_manager_attach_handler(0x9B, syscall_process_start_thread);
+    //0x09XX RESERVED
 
     // 0xAX - Memory
-    syscalls_manager_attach_handler(0xA0, syscall_memory_get_physical_memory_stats);
+    syscalls_manager_attach_handler(0x0A00, syscall_memory_get_physical_memory_stats);
     
     // 0xBX - Partitions
-    syscalls_manager_attach_handler(0xB0, syscall_partitions_get_count);
-    syscalls_manager_attach_handler(0xB1, syscall_partitions_get_symbols);
-    syscalls_manager_attach_handler(0xB2, syscall_partitions_get_info);
+    syscalls_manager_attach_handler(0x0B00, syscall_partitions_get_count);
+    syscalls_manager_attach_handler(0x0B01, syscall_partitions_get_symbols);
+    syscalls_manager_attach_handler(0x0B02, syscall_partitions_get_info);
     
     // 0xCX - Power
-    syscalls_manager_attach_handler(0xC0, syscall_power_reboot);
-    syscalls_manager_attach_handler(0xC1, syscall_power_shutdown);
+    syscalls_manager_attach_handler(0x0C00, syscall_power_reboot);
+    syscalls_manager_attach_handler(0x0C01, syscall_power_shutdown);
     
     // 0xDX - Serial
-    syscalls_manager_attach_handler(0xD0, syscall_serial_init);
-    syscalls_manager_attach_handler(0xD1, syscall_serial_is_busy);
-    syscalls_manager_attach_handler(0xD2, syscall_serial_is_queue_empty);
-    syscalls_manager_attach_handler(0xD3, syscall_serial_send);
-    syscalls_manager_attach_handler(0xD4, syscall_serial_send_string);
-    syscalls_manager_attach_handler(0xD5, syscall_serial_receive);
-
-    //0xEX - Terminal Manager Graphics Functions
-    syscalls_manager_attach_handler(0xE0, syscall_terminal_set_video_mode);
-    syscalls_manager_attach_handler(0xE1, syscall_terminal_copy_from_buffer);
+    syscalls_manager_attach_handler(0x0D00, syscall_serial_init);
+    syscalls_manager_attach_handler(0x0D01, syscall_serial_is_busy);
+    syscalls_manager_attach_handler(0x0D02, syscall_serial_is_queue_empty);
+    syscalls_manager_attach_handler(0x0D03, syscall_serial_send);
+    syscalls_manager_attach_handler(0x0D04, syscall_serial_send_string);
+    syscalls_manager_attach_handler(0x0D05, syscall_serial_receive);
 }
 
-void syscalls_manager_attach_handler(uint8_t function_number, void (*handler)(interrupt_state *state))
+void syscalls_manager_attach_handler(uint16_t function_number, void (*handler)(interrupt_state *state))
 {
     syscall_handlers[function_number] = handler;
 }
 
-void syscalls_manager_detach_handler(uint8_t function_number)
+void syscalls_manager_detach_handler(uint16_t function_number)
 {
     syscall_handlers[function_number] = 0;
 }

--- a/os/kernel/src/process/syscalls/syscalls_manager.h
+++ b/os/kernel/src/process/syscalls/syscalls_manager.h
@@ -1,7 +1,7 @@
 #ifndef SYSCALLS_MANAGER_H
 #define SYSCALLS_MANAGER_H
 
-#define SYSCALLS_MANAGER_MAX_HANDLERS 256
+#define SYSCALLS_MANAGER_MAX_HANDLERS 65536
 
 #include "cpu/idt/idt.h"
 #include "handlers/heap_calls.h"
@@ -19,8 +19,8 @@
 #include "handlers/serial_calls.h"
 
 void syscalls_manager_init();
-void syscalls_manager_attach_handler(uint8_t function_number, void (*handler)(interrupt_state *state));
-void syscalls_manager_detach_handler(uint8_t function_number);
+void syscalls_manager_attach_handler(uint16_t function_number, void (*handler)(interrupt_state *state));
+void syscalls_manager_detach_handler(uint16_t function_number);
 void syscalls_manager_call(interrupt_state *state);
 
 #endif


### PR DESCRIPTION
Each syscall group has been redefined, compare your changes to new code. If your syscalls are extending group, please change their numbering.
If you are providing new syscall group, please change numbering and use one of free group numbers (usually next one that is free). New format is is 0xZZYY, where ZZ means group number and YY is number of syscall in that group.
In future some group numbers might be freed due to merging of groups with only few syscalls.

Provides fix for Issue #97.